### PR TITLE
use gulp.watch replace gulp-watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,24 +21,25 @@
   },
   "homepage": "https://github.com/FocusCare/mix-gulp-sass",
   "dependencies": {
+    "browser-sync": "^2.11.1",
     "colors": "^1.1.2",
     "glob": "^6.0.3",
     "gulp-autoprefixer": "^3.1.0",
+    "gulp-cached": "^1.1.0",
     "gulp-log": "0.0.0",
     "gulp-md5": "^0.1.1",
     "gulp-minify-css": "^1.2.3",
     "gulp-postcss": "^6.0.1",
     "gulp-sass": "^2.0.4",
+    "gulp-sass-grapher": "^0.1.4",
     "gulp-util": "^3.0.7",
+    "gulp-watch": "^4.3.5",
     "node-qiniu": "^6.2.0",
     "node-sass": "^3.3.3",
     "q": "^1.4.1",
     "rimraf": "^2.5.0",
     "through2": "^2.0.0",
-    "upyun_cdn": "^0.1.4",
-    "browser-sync": "^2.11.1",
-    "gulp-sass-grapher": "^0.1.4",
-    "gulp-watch": "^4.3.5"
+    "upyun_cdn": "^0.1.4"
   },
   "devDependencies": {
     "gulp": "^3.9.0"


### PR DESCRIPTION
gulp-watch 在 node-sass 报错后就不会继续 pipe 了，所以改成用 gulp.watch 了。
但是 gulp.watch 也有一个问题，就是它会更新所有的文件，而不是像 gulp-watch 一样只更新变化了文件。
所以引入了 gulp-cached 包，但是这个包有一个问题就是，第一次依然会更新所有文件，后面再改动就只更新改动的文件了。
还没找到解决的办法，解决了一个大问题，但是引入了一个小问题，后面继续优化。
